### PR TITLE
Fix PullRequestComment InReplyToID

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -6364,12 +6364,12 @@ func (p *PullRequestComment) GetID() int64 {
 	return *p.ID
 }
 
-// GetInReplyTo returns the InReplyTo field if it's non-nil, zero value otherwise.
-func (p *PullRequestComment) GetInReplyTo() int64 {
-	if p == nil || p.InReplyTo == nil {
+// GetInReplyToID returns the InReplyToID field if it's non-nil, zero value otherwise.
+func (p *PullRequestComment) GetInReplyToID() int64 {
+	if p == nil || p.InReplyToID == nil {
 		return 0
 	}
-	return *p.InReplyTo
+	return *p.InReplyToID
 }
 
 // GetOriginalCommitID returns the OriginalCommitID field if it's non-nil, zero value otherwise.

--- a/github/pulls_comments.go
+++ b/github/pulls_comments.go
@@ -14,7 +14,7 @@ import (
 // PullRequestComment represents a comment left on a pull request.
 type PullRequestComment struct {
 	ID                  *int64     `json:"id,omitempty"`
-	InReplyTo           *int64     `json:"in_reply_to,omitempty"`
+	InReplyToID         *int64     `json:"in_reply_to_id,omitempty"`
 	Body                *string    `json:"body,omitempty"`
 	Path                *string    `json:"path,omitempty"`
 	DiffHunk            *string    `json:"diff_hunk,omitempty"`


### PR DESCRIPTION
The JSON tag mismatches the one returned from the API, so the value is always encoded as nil.

Relevant docs: https://developer.github.com/v3/pulls/comments/#get-a-single-comment